### PR TITLE
ShardEnd Shard Sync with ChildShard information

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ConsumerStates.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ConsumerStates.java
@@ -496,7 +496,8 @@ class ConsumerStates {
                     argument.taskBackoffTimeMillis(),
                     argument.recordsPublisher(),
                     argument.hierarchicalShardSyncer(),
-                    argument.metricsFactory());
+                    argument.metricsFactory(),
+                    input == null ? null : input.childShards());
         }
 
         @Override

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumer.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumer.java
@@ -16,6 +16,7 @@ package software.amazon.kinesis.lifecycle;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -32,6 +33,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.services.kinesis.model.ChildShard;
 import software.amazon.kinesis.annotations.KinesisClientInternalApi;
 import software.amazon.kinesis.exceptions.internal.BlockedOnParentShardException;
 import software.amazon.kinesis.leases.ShardInfo;
@@ -84,6 +86,8 @@ public class ShardConsumer {
     private volatile ShutdownNotification shutdownNotification;
 
     private final ShardConsumerSubscriber subscriber;
+
+    private ProcessRecordsInput shardEndProcessRecordsInput;
 
     @Deprecated
     public ShardConsumer(RecordsPublisher recordsPublisher, ExecutorService executorService, ShardInfo shardInfo,
@@ -146,6 +150,7 @@ public class ShardConsumer {
         processData(input);
         if (taskOutcome == TaskOutcome.END_OF_SHARD) {
             markForShutdown(ShutdownReason.SHARD_END);
+            shardEndProcessRecordsInput = input;
             subscription.cancel();
             return;
         }
@@ -303,7 +308,7 @@ public class ShardConsumer {
                     return true;
                 }
 
-                executeTask(null);
+                executeTask(shardEndProcessRecordsInput);
                 return false;
             }
         }, executorService);

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShutdownTask.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShutdownTask.java
@@ -21,6 +21,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import software.amazon.awssdk.services.kinesis.model.ChildShard;
 import software.amazon.awssdk.services.kinesis.model.Shard;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.kinesis.annotations.KinesisClientInternalApi;
@@ -32,7 +33,11 @@ import software.amazon.kinesis.leases.LeaseRefresher;
 import software.amazon.kinesis.leases.ShardDetector;
 import software.amazon.kinesis.leases.ShardInfo;
 import software.amazon.kinesis.leases.HierarchicalShardSyncer;
+import software.amazon.kinesis.leases.exceptions.DependencyException;
+import software.amazon.kinesis.leases.exceptions.InvalidStateException;
+import software.amazon.kinesis.leases.exceptions.ProvisionedThroughputException;
 import software.amazon.kinesis.lifecycle.events.LeaseLostInput;
+import software.amazon.kinesis.lifecycle.events.ProcessRecordsInput;
 import software.amazon.kinesis.lifecycle.events.ShardEndedInput;
 import software.amazon.kinesis.metrics.MetricsFactory;
 import software.amazon.kinesis.metrics.MetricsScope;
@@ -82,6 +87,8 @@ public class ShutdownTask implements ConsumerTask {
 
     private final TaskType taskType = TaskType.SHUTDOWN;
 
+    private final List<ChildShard> childShards;
+
     /*
      * Invokes ShardRecordProcessor shutdown() API.
      * (non-Javadoc)
@@ -96,68 +103,57 @@ public class ShutdownTask implements ConsumerTask {
         Exception exception;
         boolean applicationException = false;
 
+        final ShutdownReason localReason;
+        // If shut down reason is SHARD_END but childShards is empty list, this means we get to a false shard end.
+        // We should not throw exception because it will trigger another ShutdownTask which has the same empty list of childShards.
+        // Instead we should shut down the ShardConsumer with LEASE_LOST reason to allow other worker to grab lease and continue reading from this shard.
+        if(reason == ShutdownReason.SHARD_END && CollectionUtils.isNullOrEmpty(childShards)) {
+            localReason = ShutdownReason.LEASE_LOST;
+            dropLease();
+            log.warn("False shard end encountered. Forcing the lease to be lost before shutting down the consumer for Shard: {}.", shardInfo.shardId());
+        } else {
+            localReason = reason;
+        }
+
         try {
             try {
-                ShutdownReason localReason = reason;
-                List<Shard> latestShards = null;
-                /*
-                 * Revalidate if the current shard is closed before shutting down the shard consumer with reason SHARD_END
-                 * If current shard is not closed, shut down the shard consumer with reason LEASE_LOST that allows
-                 * active workers to contend for the lease of this shard.
-                 */
-                if (localReason == ShutdownReason.SHARD_END) {
-                    latestShards = shardDetector.listShards();
+                log.debug("Invoking shutdown() for shard {}, concurrencyToken {}. Shutdown reason: {}",
+                        shardInfo.shardId(), shardInfo.concurrencyToken(), localReason);
 
-                    //If latestShards is empty, should also shutdown the ShardConsumer without checkpoint with SHARD_END
-                    if (CollectionUtils.isNullOrEmpty(latestShards) || !isShardInContextParentOfAny(latestShards)) {
-                        localReason = ShutdownReason.LEASE_LOST;
-                        dropLease();
-                        log.info("Forcing the lease to be lost before shutting down the consumer for Shard: " + shardInfo.shardId());
-                    }
-                }
-
-                // If we reached end of the shard, set sequence number to SHARD_END.
+                final long startTime = System.currentTimeMillis();
                 if (localReason == ShutdownReason.SHARD_END) {
+                    // Create new lease for the child shards if they don't exist.
+                    createLeasesForChildShardsIfNotExist();
+
                     recordProcessorCheckpointer
                             .sequenceNumberAtShardEnd(recordProcessorCheckpointer.largestPermittedCheckpointValue());
                     recordProcessorCheckpointer.largestPermittedCheckpointValue(ExtendedSequenceNumber.SHARD_END);
-                }
-
-                log.debug("Invoking shutdown() for shard {}, concurrencyToken {}. Shutdown reason: {}",
-                        shardInfo.shardId(), shardInfo.concurrencyToken(), localReason);
-                final ShutdownInput shutdownInput = ShutdownInput.builder().shutdownReason(localReason)
-                        .checkpointer(recordProcessorCheckpointer).build();
-                final long startTime = System.currentTimeMillis();
-                try {
-                    if (localReason == ShutdownReason.SHARD_END) {
+                    // Call the shardReocrdsProcessor to checkpoint with SHARD_END sequence number.
+                    // The shardEnded is implemented by customer. We should validate if the Shard_End checkpointing is successful after calling shardEnded.
+                    try {
                         shardRecordProcessor.shardEnded(ShardEndedInput.builder().checkpointer(recordProcessorCheckpointer).build());
-                        ExtendedSequenceNumber lastCheckpointValue = recordProcessorCheckpointer.lastCheckpointValue();
+                        final ExtendedSequenceNumber lastCheckpointValue = recordProcessorCheckpointer.lastCheckpointValue();
                         if (lastCheckpointValue == null
                                 || !lastCheckpointValue.equals(ExtendedSequenceNumber.SHARD_END)) {
                             throw new IllegalArgumentException("Application didn't checkpoint at end of shard "
-                                    + shardInfo.shardId() + ". Application must checkpoint upon shard end. " +
-                                    "See ShardRecordProcessor.shardEnded javadocs for more information.");
+                                                                       + shardInfo.shardId() + ". Application must checkpoint upon shard end. " +
+                                                                       "See ShardRecordProcessor.shardEnded javadocs for more information.");
                         }
-                    } else {
-                        shardRecordProcessor.leaseLost(LeaseLostInput.builder().build());
+                    } catch (Exception e) {
+                        applicationException = true;
+                        throw e;
+                    } finally {
+                        MetricsUtil.addLatency(scope, RECORD_PROCESSOR_SHUTDOWN_METRIC, startTime, MetricsLevel.SUMMARY);
                     }
-                    log.debug("Shutting down retrieval strategy.");
-                    recordsPublisher.shutdown();
-                    log.debug("Record processor completed shutdown() for shard {}", shardInfo.shardId());
-                } catch (Exception e) {
-                    applicationException = true;
-                    throw e;
-                } finally {
-                    MetricsUtil.addLatency(scope, RECORD_PROCESSOR_SHUTDOWN_METRIC, startTime, MetricsLevel.SUMMARY);
+                    // Drop the current lease.
+                    dropLease();
+                } else {
+                    shardRecordProcessor.leaseLost(LeaseLostInput.builder().build());
                 }
 
-                if (localReason == ShutdownReason.SHARD_END) {
-                    log.debug("Looking for child shards of shard {}", shardInfo.shardId());
-                    // create leases for the child shards
-                    hierarchicalShardSyncer.checkAndCreateLeaseForNewShards(shardDetector, leaseCoordinator.leaseRefresher(),
-                            initialPositionInStream, cleanupLeasesOfCompletedShards, ignoreUnexpectedChildShards, scope, latestShards);
-                    log.debug("Finished checking for child shards of shard {}", shardInfo.shardId());
-                }
+                log.debug("Shutting down retrieval strategy.");
+                recordsPublisher.shutdown();
+                log.debug("Record processor completed shutdown() for shard {}", shardInfo.shardId());
 
                 return new TaskResult(null);
             } catch (Exception e) {
@@ -179,7 +175,28 @@ public class ShutdownTask implements ConsumerTask {
         }
 
         return new TaskResult(exception);
+    }
 
+    private void createLeasesForChildShardsIfNotExist()
+            throws RuntimeException, DependencyException, InvalidStateException, ProvisionedThroughputException {
+        for(ChildShard childShard : childShards) {
+            if(leaseCoordinator.getCurrentlyHeldLease(shardInfo.shardId()) == null) {
+                final Lease leaseToCreate = createNewLeaseForShard(childShard);
+                leaseCoordinator.leaseRefresher().createLeaseIfNotExists(leaseToCreate);
+            }
+        }
+    }
+
+    private Lease createNewLeaseForShard(ChildShard childShard) {
+        Lease newLease = new Lease();
+        newLease.leaseKey(childShard.shardId());
+        if (!CollectionUtils.isNullOrEmpty(childShard.parentShards())) {
+            newLease.parentShardIds(childShard.parentShards());
+        } else {
+            throw new RuntimeException("Unable to populate new lease for child shard " + childShard.shardId() + "because parent shards cannot be found.");
+        }
+        newLease.ownerSwitchesSinceCheckpoint(0L);
+        return newLease;
     }
 
     /*

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/events/ProcessRecordsInput.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/events/ProcessRecordsInput.java
@@ -23,6 +23,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.experimental.Accessors;
+import software.amazon.awssdk.services.kinesis.model.ChildShard;
 import software.amazon.kinesis.processor.ShardRecordProcessor;
 import software.amazon.kinesis.processor.RecordProcessorCheckpointer;
 import software.amazon.kinesis.retrieval.KinesisClientRecord;
@@ -66,6 +67,11 @@ public class ProcessRecordsInput {
      * This value does not include the {@link #timeSpentInCache()}.
      */
     private Long millisBehindLatest;
+    /**
+     * A list of child shards if the current GetRecords request reached the shard end.
+     * If not at the shard end, this should be an empty list.
+     */
+    private List<ChildShard> childShards;
 
     /**
      * How long the records spent waiting to be dispatched to the {@link ShardRecordProcessor}

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/BlockingRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/BlockingRecordsPublisher.java
@@ -67,6 +67,7 @@ public class BlockingRecordsPublisher implements RecordsPublisher {
         return ProcessRecordsInput.builder()
                 .records(records)
                 .millisBehindLatest(getRecordsResult.millisBehindLatest())
+                .childShards(getRecordsResult.childShards())
                 .build();
     }
 

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/KinesisDataFetcher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/KinesisDataFetcher.java
@@ -36,6 +36,7 @@ import software.amazon.awssdk.services.kinesis.model.GetShardIteratorRequest;
 import software.amazon.awssdk.services.kinesis.model.GetShardIteratorResponse;
 import software.amazon.awssdk.services.kinesis.model.KinesisException;
 import software.amazon.awssdk.services.kinesis.model.ResourceNotFoundException;
+import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.kinesis.annotations.KinesisClientInternalApi;
 import software.amazon.kinesis.common.FutureUtils;
 import software.amazon.kinesis.common.InitialPositionInStreamExtended;
@@ -108,7 +109,13 @@ public class KinesisDataFetcher {
 
         if (nextIterator != null) {
             try {
-                return new AdvancingResult(getRecords(nextIterator));
+                GetRecordsResponse getRecordsResponse = getRecords(nextIterator);
+                while (!isValidResponse(getRecordsResponse)) {
+                    log.error("{} : GetRecords response is not valid. nextShardIterator: {}. childShards: {}. Will retry GetRecords with the same nextIterator.",
+                              shardId, getRecordsResponse.nextShardIterator(), getRecordsResponse.childShards());
+                    getRecordsResponse = getRecords(nextIterator);
+                }
+                return new AdvancingResult(getRecordsResponse);
             } catch (ResourceNotFoundException e) {
                 log.info("Caught ResourceNotFoundException when fetching records for shard {}", shardId);
                 return TERMINAL_RESULT;
@@ -121,8 +128,12 @@ public class KinesisDataFetcher {
     final DataFetcherResult TERMINAL_RESULT = new DataFetcherResult() {
         @Override
         public GetRecordsResponse getResult() {
-            return GetRecordsResponse.builder().millisBehindLatest(null).records(Collections.emptyList())
-                    .nextShardIterator(null).build();
+            return GetRecordsResponse.builder()
+                                     .millisBehindLatest(null)
+                                     .records(Collections.emptyList())
+                                     .nextShardIterator(null)
+                                     .childShards(Collections.emptyList())
+                                     .build();
         }
 
         @Override
@@ -163,6 +174,11 @@ public class KinesisDataFetcher {
         public boolean isShardEnd() {
             return isShardEndReached;
         }
+    }
+
+    private boolean isValidResponse(GetRecordsResponse response) {
+            return response.nextShardIterator() == null ? !CollectionUtils.isNullOrEmpty(response.childShards())
+                                                        : response.childShards() != null && response.childShards().isEmpty();
     }
 
     /**

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
@@ -18,6 +18,7 @@ package software.amazon.kinesis.retrieval.polling;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -428,13 +429,6 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
                 try {
                     sleepBeforeNextCall();
                     GetRecordsResponse getRecordsResult = getRecordsRetrievalStrategy.getRecords(maxRecordsPerCall);
-
-                    if(!isValidResponse(getRecordsResult)) {
-                        throw new RuntimeException("GetRecordRespoinse is invalid for shard " + shardId
-                                                    + ". nextShardIterator: " + getRecordsResult.nextShardIterator()
-                                                    + ". childShards: " + getRecordsResult.childShards());
-                    }
-
                     lastSuccessfulCall = Instant.now();
 
                     final List<KinesisClientRecord> records = getRecordsResult.records().stream()
@@ -487,11 +481,6 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
                             "Shutdown has probably been started", shardId);
                 }
             }
-        }
-
-        private boolean isValidResponse(GetRecordsResponse response) {
-            return response.nextShardIterator() == null ? !CollectionUtils.isNullOrEmpty(response.childShards())
-                                                        : response.childShards() != null && response.childShards().isEmpty();
         }
 
         private void callShutdownOnStrategy() {

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ConsumerStatesTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ConsumerStatesTest.java
@@ -25,6 +25,8 @@ import static org.mockito.Mockito.when;
 import static software.amazon.kinesis.lifecycle.ConsumerStates.ShardConsumerState;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
@@ -40,6 +42,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
+import software.amazon.awssdk.services.kinesis.model.ChildShard;
 import software.amazon.kinesis.checkpoint.ShardRecordProcessorCheckpointer;
 import software.amazon.kinesis.common.InitialPositionInStream;
 import software.amazon.kinesis.common.InitialPositionInStreamExtended;
@@ -48,6 +51,7 @@ import software.amazon.kinesis.leases.LeaseRefresher;
 import software.amazon.kinesis.leases.ShardDetector;
 import software.amazon.kinesis.leases.ShardInfo;
 import software.amazon.kinesis.leases.HierarchicalShardSyncer;
+import software.amazon.kinesis.leases.ShardObjectHelper;
 import software.amazon.kinesis.lifecycle.events.ProcessRecordsInput;
 import software.amazon.kinesis.metrics.MetricsFactory;
 import software.amazon.kinesis.processor.Checkpointer;
@@ -57,6 +61,7 @@ import software.amazon.kinesis.retrieval.AggregatorUtil;
 import software.amazon.kinesis.retrieval.RecordsPublisher;
 
 import javax.swing.*;
+import javax.swing.text.AsyncBoxView;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ConsumerStatesTest {
@@ -301,13 +306,27 @@ public class ConsumerStatesTest {
 
     }
 
-    // TODO: Fix this test
-    @Ignore
     @Test
     public void shuttingDownStateTest() {
         consumer.markForShutdown(ShutdownReason.SHARD_END);
         ConsumerState state = ShardConsumerState.SHUTTING_DOWN.consumerState();
-        ConsumerTask task = state.createTask(argument, consumer, null);
+        List<ChildShard> childShards = new ArrayList<>();
+        List<String> parentShards = new ArrayList<>();
+        parentShards.add("shardId-000000000000");
+        ChildShard leftChild = ChildShard.builder()
+                                         .shardId("shardId-000000000001")
+                                         .parentShards(parentShards)
+                                         .hashKeyRange(ShardObjectHelper.newHashKeyRange("0", "49"))
+                                         .build();
+        ChildShard rightChild = ChildShard.builder()
+                                          .shardId("shardId-000000000002")
+                                          .parentShards(parentShards)
+                                          .hashKeyRange(ShardObjectHelper.newHashKeyRange("50", "99"))
+                                          .build();
+        childShards.add(leftChild);
+        childShards.add(rightChild);
+        when(processRecordsInput.childShards()).thenReturn(childShards);
+        ConsumerTask task = state.createTask(argument, consumer, processRecordsInput);
 
         assertThat(task, shutdownTask(ShardInfo.class, "shardInfo", equalTo(shardInfo)));
         assertThat(task,
@@ -316,8 +335,6 @@ public class ConsumerStatesTest {
                 equalTo(recordProcessorCheckpointer)));
         assertThat(task, shutdownTask(ShutdownReason.class, "reason", equalTo(reason)));
         assertThat(task, shutdownTask(LeaseCoordinator.class, "leaseCoordinator", equalTo(leaseCoordinator)));
-        assertThat(task, shutdownTask(InitialPositionInStreamExtended.class, "initialPositionInStream",
-                equalTo(initialPositionInStream)));
         assertThat(task,
                 shutdownTask(Boolean.class, "cleanupLeasesOfCompletedShards", equalTo(cleanupLeasesOfCompletedShards)));
         assertThat(task, shutdownTask(Long.class, "backoffTimeMillis", equalTo(taskBackoffTimeMillis)));

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShutdownTaskTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShutdownTaskTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -32,9 +33,11 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import software.amazon.awssdk.services.kinesis.model.ChildShard;
 import software.amazon.awssdk.services.kinesis.model.SequenceNumberRange;
 import software.amazon.awssdk.services.kinesis.model.Shard;
 import software.amazon.kinesis.checkpoint.ShardRecordProcessorCheckpointer;
@@ -48,6 +51,9 @@ import software.amazon.kinesis.leases.LeaseRefresher;
 import software.amazon.kinesis.leases.ShardDetector;
 import software.amazon.kinesis.leases.ShardInfo;
 import software.amazon.kinesis.leases.ShardObjectHelper;
+import software.amazon.kinesis.leases.exceptions.DependencyException;
+import software.amazon.kinesis.leases.exceptions.InvalidStateException;
+import software.amazon.kinesis.leases.exceptions.ProvisionedThroughputException;
 import software.amazon.kinesis.lifecycle.events.LeaseLostInput;
 import software.amazon.kinesis.lifecycle.events.ShardEndedInput;
 import software.amazon.kinesis.metrics.MetricsFactory;
@@ -104,7 +110,7 @@ public class ShutdownTaskTest {
         task = new ShutdownTask(shardInfo, shardDetector, shardRecordProcessor, recordProcessorCheckpointer,
                 SHARD_END_SHUTDOWN_REASON, INITIAL_POSITION_TRIM_HORIZON, cleanupLeasesOfCompletedShards,
                 ignoreUnexpectedChildShards, leaseCoordinator, TASK_BACKOFF_TIME_MILLIS, recordsPublisher,
-                hierarchicalShardSyncer, NULL_METRICS_FACTORY);
+                hierarchicalShardSyncer, NULL_METRICS_FACTORY, constructChildShards());
     }
 
     /**
@@ -113,8 +119,8 @@ public class ShutdownTaskTest {
      */
     @Test
     public final void testCallWhenApplicationDoesNotCheckpoint() {
-        when(shardDetector.listShards()).thenReturn(constructShardListGraphA());
         when(recordProcessorCheckpointer.lastCheckpointValue()).thenReturn(new ExtendedSequenceNumber("3298"));
+        when(leaseCoordinator.leaseRefresher()).thenReturn(leaseRefresher);
 
         final TaskResult result = task.call();
         assertNotNull(result.getException());
@@ -126,25 +132,18 @@ public class ShutdownTaskTest {
      * This test is for the scenario that checkAndCreateLeaseForNewShards throws an exception.
      */
     @Test
-    public final void testCallWhenSyncingShardsThrows() throws Exception {
-        List<Shard> latestShards = constructShardListGraphA();
-        when(shardDetector.listShards()).thenReturn(latestShards);
+    public final void testCallWhenCreatingNewLeasesThrows() throws Exception {
         when(recordProcessorCheckpointer.lastCheckpointValue()).thenReturn(ExtendedSequenceNumber.SHARD_END);
         when(leaseCoordinator.leaseRefresher()).thenReturn(leaseRefresher);
-
-        doAnswer((invocation) -> {
-            throw new KinesisClientLibIOException("KinesisClientLibIOException");
-        }).when(hierarchicalShardSyncer)
-                .checkAndCreateLeaseForNewShards(shardDetector, leaseRefresher, INITIAL_POSITION_TRIM_HORIZON,
-                        cleanupLeasesOfCompletedShards, ignoreUnexpectedChildShards,
-                        NULL_METRICS_FACTORY.createMetrics(), latestShards);
+        when(leaseRefresher.createLeaseIfNotExists(Matchers.any(Lease.class))).thenThrow(new KinesisClientLibIOException("KinesisClientLibIOException"));
 
         final TaskResult result = task.call();
         assertNotNull(result.getException());
         assertTrue(result.getException() instanceof KinesisClientLibIOException);
-        verify(recordsPublisher).shutdown();
-        verify(shardRecordProcessor).shardEnded(ShardEndedInput.builder().checkpointer(recordProcessorCheckpointer).build());
+        verify(recordsPublisher, never()).shutdown();
+        verify(shardRecordProcessor, never()).shardEnded(ShardEndedInput.builder().checkpointer(recordProcessorCheckpointer).build());
         verify(shardRecordProcessor, never()).leaseLost(LeaseLostInput.builder().build());
+        verify(leaseCoordinator, never()).dropLease(Matchers.any(Lease.class));
     }
 
     /**
@@ -152,24 +151,24 @@ public class ShutdownTaskTest {
      * This test is for the scenario that ShutdownTask is created for ShardConsumer reaching the Shard End.
      */
     @Test
-    public final void testCallWhenTrueShardEnd() {
+    public final void testCallWhenTrueShardEnd() throws DependencyException, InvalidStateException, ProvisionedThroughputException {
         shardInfo = new ShardInfo("shardId-0", concurrencyToken, Collections.emptySet(),
                                   ExtendedSequenceNumber.LATEST);
         task = new ShutdownTask(shardInfo, shardDetector, shardRecordProcessor, recordProcessorCheckpointer,
                                 SHARD_END_SHUTDOWN_REASON, INITIAL_POSITION_TRIM_HORIZON, cleanupLeasesOfCompletedShards,
                                 ignoreUnexpectedChildShards, leaseCoordinator, TASK_BACKOFF_TIME_MILLIS, recordsPublisher,
-                                hierarchicalShardSyncer, NULL_METRICS_FACTORY);
+                                hierarchicalShardSyncer, NULL_METRICS_FACTORY, constructChildShards());
 
-        when(shardDetector.listShards()).thenReturn(constructShardListGraphA());
         when(recordProcessorCheckpointer.lastCheckpointValue()).thenReturn(ExtendedSequenceNumber.SHARD_END);
+        when(leaseCoordinator.leaseRefresher()).thenReturn(leaseRefresher);
 
         final TaskResult result = task.call();
         assertNull(result.getException());
         verify(recordsPublisher).shutdown();
         verify(shardRecordProcessor).shardEnded(ShardEndedInput.builder().checkpointer(recordProcessorCheckpointer).build());
         verify(shardRecordProcessor, never()).leaseLost(LeaseLostInput.builder().build());
-        verify(shardDetector, times(1)).listShards();
-        verify(leaseCoordinator, never()).getAssignments();
+        verify(leaseRefresher, times(2)).createLeaseIfNotExists(Matchers.any(Lease.class));
+        verify(leaseCoordinator).dropLease(Matchers.any(Lease.class));
     }
 
     /**
@@ -177,23 +176,22 @@ public class ShutdownTaskTest {
      * This test is for the scenario that a ShutdownTask is created for detecting a false Shard End.
      */
     @Test
-    public final void testCallWhenFalseShardEnd() {
+    public final void testCallWhenFalseShardEnd() throws DependencyException, InvalidStateException, ProvisionedThroughputException {
         shardInfo = new ShardInfo("shardId-4", concurrencyToken, Collections.emptySet(),
                                   ExtendedSequenceNumber.LATEST);
         task = new ShutdownTask(shardInfo, shardDetector, shardRecordProcessor, recordProcessorCheckpointer,
                                 SHARD_END_SHUTDOWN_REASON, INITIAL_POSITION_TRIM_HORIZON, cleanupLeasesOfCompletedShards,
                                 ignoreUnexpectedChildShards, leaseCoordinator, TASK_BACKOFF_TIME_MILLIS, recordsPublisher,
-                                hierarchicalShardSyncer, NULL_METRICS_FACTORY);
-
-        when(shardDetector.listShards()).thenReturn(constructShardListGraphA());
+                                hierarchicalShardSyncer, NULL_METRICS_FACTORY, new ArrayList<>());
 
         final TaskResult result = task.call();
         assertNull(result.getException());
         verify(recordsPublisher).shutdown();
         verify(shardRecordProcessor, never()).shardEnded(ShardEndedInput.builder().checkpointer(recordProcessorCheckpointer).build());
         verify(shardRecordProcessor).leaseLost(LeaseLostInput.builder().build());
-        verify(shardDetector, times(1)).listShards();
         verify(leaseCoordinator).getCurrentlyHeldLease(shardInfo.shardId());
+        verify(leaseRefresher, never()).createLeaseIfNotExists(Matchers.any(Lease.class));
+        verify(leaseCoordinator).dropLease(Matchers.any(Lease.class));
     }
 
     /**
@@ -201,23 +199,22 @@ public class ShutdownTaskTest {
      * This test is for the scenario that a ShutdownTask is created for the ShardConsumer losing the lease.
      */
     @Test
-    public final void testCallWhenLeaseLost() {
+    public final void testCallWhenLeaseLost() throws DependencyException, InvalidStateException, ProvisionedThroughputException {
         shardInfo = new ShardInfo("shardId-4", concurrencyToken, Collections.emptySet(),
                                   ExtendedSequenceNumber.LATEST);
         task = new ShutdownTask(shardInfo, shardDetector, shardRecordProcessor, recordProcessorCheckpointer,
                                 LEASE_LOST_SHUTDOWN_REASON, INITIAL_POSITION_TRIM_HORIZON, cleanupLeasesOfCompletedShards,
                                 ignoreUnexpectedChildShards, leaseCoordinator, TASK_BACKOFF_TIME_MILLIS, recordsPublisher,
-                                hierarchicalShardSyncer, NULL_METRICS_FACTORY);
-
-        when(shardDetector.listShards()).thenReturn(constructShardListGraphA());
+                                hierarchicalShardSyncer, NULL_METRICS_FACTORY, new ArrayList<>());
 
         final TaskResult result = task.call();
         assertNull(result.getException());
         verify(recordsPublisher).shutdown();
         verify(shardRecordProcessor, never()).shardEnded(ShardEndedInput.builder().checkpointer(recordProcessorCheckpointer).build());
         verify(shardRecordProcessor).leaseLost(LeaseLostInput.builder().build());
-        verify(shardDetector, never()).listShards();
         verify(leaseCoordinator, never()).getAssignments();
+        verify(leaseRefresher, never()).createLeaseIfNotExists(Matchers.any(Lease.class));
+        verify(leaseCoordinator, never()).dropLease(Matchers.any(Lease.class));
     }
 
     /**
@@ -228,45 +225,23 @@ public class ShutdownTaskTest {
         assertEquals(TaskType.SHUTDOWN, task.taskType());
     }
 
-
-    /*
-     * Helper method to construct a shard list for graph A. Graph A is defined below. Shard structure (y-axis is
-     * epochs): 0 1 2 3 4   5  - shards till
-     *          \ / \ / |   |
-     *           6   7  4   5  - shards from epoch 103 - 205
-     *            \ /   |  /\
-     *             8    4 9 10 - shards from epoch 206 (open - no ending sequenceNumber)
-     */
-    private List<Shard> constructShardListGraphA() {
-        final SequenceNumberRange range0 = ShardObjectHelper.newSequenceNumberRange("11", "102");
-        final SequenceNumberRange range1 = ShardObjectHelper.newSequenceNumberRange("11", null);
-        final SequenceNumberRange range2 = ShardObjectHelper.newSequenceNumberRange("11", "205");
-        final SequenceNumberRange range3 = ShardObjectHelper.newSequenceNumberRange("103", "205");
-        final SequenceNumberRange range4 = ShardObjectHelper.newSequenceNumberRange("206", null);
-
-        return Arrays.asList(
-                ShardObjectHelper.newShard("shardId-0", null, null, range0,
-                                           ShardObjectHelper.newHashKeyRange("0", "99")),
-                ShardObjectHelper.newShard("shardId-1", null, null, range0,
-                                           ShardObjectHelper.newHashKeyRange("100", "199")),
-                ShardObjectHelper.newShard("shardId-2", null, null, range0,
-                                           ShardObjectHelper.newHashKeyRange("200", "299")),
-                ShardObjectHelper.newShard("shardId-3", null, null, range0,
-                                           ShardObjectHelper.newHashKeyRange("300", "399")),
-                ShardObjectHelper.newShard("shardId-4", null, null, range1,
-                                           ShardObjectHelper.newHashKeyRange("400", "499")),
-                ShardObjectHelper.newShard("shardId-5", null, null, range2,
-                                           ShardObjectHelper.newHashKeyRange("500", ShardObjectHelper.MAX_HASH_KEY)),
-                ShardObjectHelper.newShard("shardId-6", "shardId-0", "shardId-1", range3,
-                                           ShardObjectHelper.newHashKeyRange("0", "199")),
-                ShardObjectHelper.newShard("shardId-7", "shardId-2", "shardId-3", range3,
-                                           ShardObjectHelper.newHashKeyRange("200", "399")),
-                ShardObjectHelper.newShard("shardId-8", "shardId-6", "shardId-7", range4,
-                                           ShardObjectHelper.newHashKeyRange("0", "399")),
-                ShardObjectHelper.newShard("shardId-9", "shardId-5", null, range4,
-                                           ShardObjectHelper.newHashKeyRange("500", "799")),
-                ShardObjectHelper.newShard("shardId-10", null, "shardId-5", range4,
-                                           ShardObjectHelper.newHashKeyRange("800", ShardObjectHelper.MAX_HASH_KEY)));
+    private List<ChildShard> constructChildShards() {
+        List<ChildShard> childShards = new ArrayList<>();
+        List<String> parentShards = new ArrayList<>();
+        parentShards.add(shardId);
+        ChildShard leftChild = ChildShard.builder()
+                                         .shardId("ShardId-1")
+                                         .parentShards(parentShards)
+                                         .hashKeyRange(ShardObjectHelper.newHashKeyRange("0", "49"))
+                                         .build();
+        ChildShard rightChild = ChildShard.builder()
+                                         .shardId("ShardId-2")
+                                         .parentShards(parentShards)
+                                         .hashKeyRange(ShardObjectHelper.newHashKeyRange("50", "99"))
+                                         .build();
+        childShards.add(leftChild);
+        childShards.add(rightChild);
+        return  childShards;
     }
 
 }

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisherTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisherTest.java
@@ -49,6 +49,7 @@ import software.amazon.kinesis.utils.SubscribeToShardRequestMatcher;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -151,7 +152,12 @@ public class FanOutRecordsPublisherTest {
         List<KinesisClientRecordMatcher> matchers = records.stream().map(KinesisClientRecordMatcher::new)
                 .collect(Collectors.toList());
 
-        batchEvent = SubscribeToShardEvent.builder().millisBehindLatest(100L).records(records).continuationSequenceNumber("test").build();
+        batchEvent = SubscribeToShardEvent.builder()
+                                          .millisBehindLatest(100L)
+                                          .records(records)
+                                          .continuationSequenceNumber("test")
+                                          .childShards(Collections.emptyList())
+                                          .build();
 
         captor.getValue().onNext(batchEvent);
         captor.getValue().onNext(batchEvent);
@@ -217,7 +223,7 @@ public class FanOutRecordsPublisherTest {
                                                            .collect(Collectors.toList());
 
         batchEvent = SubscribeToShardEvent.builder().millisBehindLatest(100L).records(records).continuationSequenceNumber(CONTINUATION_SEQUENCE_NUMBER).build();
-        SubscribeToShardEvent invalidEvent = SubscribeToShardEvent.builder().millisBehindLatest(100L).records(records).build();
+        SubscribeToShardEvent invalidEvent = SubscribeToShardEvent.builder().millisBehindLatest(100L).records(records).childShards(Collections.emptyList()).build();
 
         captor.getValue().onNext(batchEvent);
         captor.getValue().onNext(invalidEvent);
@@ -295,7 +301,9 @@ public class FanOutRecordsPublisherTest {
                         SubscribeToShardEvent.builder()
                                 .millisBehindLatest(100L)
                                 .continuationSequenceNumber(contSeqNum)
-                                .records(records).build())
+                                .records(records)
+                                .childShards(Collections.emptyList())
+                                .build())
                 .forEach(batchEvent -> captor.getValue().onNext(batchEvent));
 
         verify(subscription, times(4)).request(1);
@@ -371,7 +379,9 @@ public class FanOutRecordsPublisherTest {
                         SubscribeToShardEvent.builder()
                                 .millisBehindLatest(100L)
                                 .continuationSequenceNumber(contSeqNum)
-                                .records(records).build())
+                                .records(records)
+                                .childShards(Collections.emptyList())
+                                .build())
                 .forEach(batchEvent -> captor.getValue().onNext(batchEvent));
 
         verify(subscription, times(2)).request(1);
@@ -404,6 +414,7 @@ public class FanOutRecordsPublisherTest {
                         .millisBehindLatest(100L)
                         .continuationSequenceNumber(contSeqNum + "")
                         .records(records)
+                        .childShards(Collections.emptyList())
                         .build());
 
         CountDownLatch servicePublisherTaskCompletionLatch = new CountDownLatch(2);
@@ -506,6 +517,7 @@ public class FanOutRecordsPublisherTest {
                         .millisBehindLatest(100L)
                         .continuationSequenceNumber(contSeqNum + "")
                         .records(records)
+                        .childShards(Collections.emptyList())
                         .build());
 
         CountDownLatch servicePublisherTaskCompletionLatch = new CountDownLatch(2);
@@ -606,6 +618,7 @@ public class FanOutRecordsPublisherTest {
                         .millisBehindLatest(100L)
                         .continuationSequenceNumber(contSeqNum + "")
                         .records(records)
+                        .childShards(Collections.emptyList())
                         .build());
 
         List<ChildShard> childShards = new ArrayList<>();
@@ -734,6 +747,7 @@ public class FanOutRecordsPublisherTest {
                         .millisBehindLatest(100L)
                         .continuationSequenceNumber(contSeqNum + "")
                         .records(records)
+                        .childShards(Collections.emptyList())
                         .build());
 
         CountDownLatch servicePublisherTaskCompletionLatch = new CountDownLatch(2);
@@ -836,6 +850,7 @@ public class FanOutRecordsPublisherTest {
                         .millisBehindLatest(100L)
                         .continuationSequenceNumber(contSeqNum + "")
                         .records(records)
+                        .childShards(Collections.emptyList())
                         .build());
 
         CountDownLatch servicePublisherTaskCompletionLatch = new CountDownLatch(2);
@@ -928,6 +943,7 @@ public class FanOutRecordsPublisherTest {
                         .millisBehindLatest(100L)
                         .continuationSequenceNumber(contSeqNum + "")
                         .records(records)
+                        .childShards(Collections.emptyList())
                         .build());
 
         CountDownLatch servicePublisherTaskCompletionLatch = new CountDownLatch(1);
@@ -1090,7 +1106,12 @@ public class FanOutRecordsPublisherTest {
         List<KinesisClientRecordMatcher> matchers = records.stream().map(KinesisClientRecordMatcher::new)
                 .collect(Collectors.toList());
 
-        batchEvent = SubscribeToShardEvent.builder().millisBehindLatest(100L).records(records).continuationSequenceNumber(CONTINUATION_SEQUENCE_NUMBER).build();
+        batchEvent = SubscribeToShardEvent.builder()
+                                          .millisBehindLatest(100L)
+                                          .records(records)
+                                          .continuationSequenceNumber(CONTINUATION_SEQUENCE_NUMBER)
+                                          .childShards(Collections.emptyList())
+                                          .build();
 
         captor.getValue().onNext(batchEvent);
         captor.getValue().onNext(batchEvent);
@@ -1184,7 +1205,7 @@ public class FanOutRecordsPublisherTest {
                 .collect(Collectors.toList());
 
         batchEvent = SubscribeToShardEvent.builder().millisBehindLatest(100L).records(records)
-                .continuationSequenceNumber("3").build();
+                .continuationSequenceNumber("3").childShards(Collections.emptyList()).build();
 
         captor.getValue().onNext(batchEvent);
         captor.getValue().onComplete();
@@ -1212,7 +1233,7 @@ public class FanOutRecordsPublisherTest {
                 .collect(Collectors.toList());
 
         batchEvent = SubscribeToShardEvent.builder().millisBehindLatest(100L).records(nextRecords)
-                .continuationSequenceNumber("6").build();
+                .continuationSequenceNumber("6").childShards(Collections.emptyList()).build();
         nextSubscribeCaptor.getValue().onNext(batchEvent);
 
         verify(subscription, times(4)).request(1);

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherIntegrationTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherIntegrationTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -48,6 +49,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 
 import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
 import software.amazon.kinesis.common.InitialPositionInStreamExtended;
 
 import lombok.extern.slf4j.Slf4j;
@@ -86,6 +88,7 @@ public class PrefetchRecordsPublisherIntegrationTest {
     private String operation = "ProcessTask";
     private String streamName = "streamName";
     private String shardId = "shardId-000000000000";
+    private String nextShardIterator = "testNextShardIterator";
 
     @Mock
     private KinesisAsyncClient kinesisClient;
@@ -249,7 +252,7 @@ public class PrefetchRecordsPublisherIntegrationTest {
 
         @Override
         public DataFetcherResult getRecords() {
-            GetRecordsResponse getRecordsResult = GetRecordsResponse.builder().records(new ArrayList<>(records)).millisBehindLatest(1000L).build();
+            GetRecordsResponse getRecordsResult = GetRecordsResponse.builder().records(new ArrayList<>(records)).nextShardIterator(nextShardIterator).millisBehindLatest(1000L).build();
 
             return new AdvancingResult(getRecordsResult);
         }

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -71,11 +72,13 @@ import io.reactivex.Flowable;
 import io.reactivex.schedulers.Schedulers;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kinesis.model.ChildShard;
 import software.amazon.awssdk.services.kinesis.model.ExpiredIteratorException;
 import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
 import software.amazon.awssdk.services.kinesis.model.Record;
 import software.amazon.kinesis.common.InitialPositionInStreamExtended;
 import software.amazon.kinesis.common.RequestDetails;
+import software.amazon.kinesis.leases.ShardObjectHelper;
 import software.amazon.kinesis.lifecycle.ShardConsumerNotifyingSubscriber;
 import software.amazon.kinesis.lifecycle.events.ProcessRecordsInput;
 import software.amazon.kinesis.metrics.NullMetricsFactory;
@@ -98,6 +101,7 @@ public class PrefetchRecordsPublisherTest {
     private static final int MAX_SIZE = 5;
     private static final int MAX_RECORDS_COUNT = 15000;
     private static final long IDLE_MILLIS_BETWEEN_CALLS = 0L;
+    private static final String NEXT_SHARD_ITERATOR = "testNextShardIterator";
 
     @Mock
     private GetRecordsRetrievalStrategy getRecordsRetrievalStrategy;
@@ -135,7 +139,7 @@ public class PrefetchRecordsPublisherTest {
                 "shardId");
         spyQueue = spy(getRecordsCache.getPublisherSession().prefetchRecordsQueue());
         records = spy(new ArrayList<>());
-        getRecordsResponse = GetRecordsResponse.builder().records(records).build();
+        getRecordsResponse = GetRecordsResponse.builder().records(records).nextShardIterator(NEXT_SHARD_ITERATOR).childShards(new ArrayList<>()).build();
 
         when(getRecordsRetrievalStrategy.getRecords(eq(MAX_RECORDS_PER_CALL))).thenReturn(getRecordsResponse);
     }
@@ -154,9 +158,65 @@ public class PrefetchRecordsPublisherTest {
                 .processRecordsInput();
 
         assertEquals(expectedRecords, result.records());
+        assertEquals(new ArrayList<>(), result.childShards());
 
         verify(executorService).execute(any());
         verify(getRecordsRetrievalStrategy, atLeast(1)).getRecords(eq(MAX_RECORDS_PER_CALL));
+    }
+
+    @Test
+    public void testGetRecordsWithInvalidResponse() {
+        record = Record.builder().data(createByteBufferWithSize(SIZE_512_KB)).build();
+
+        when(records.size()).thenReturn(1000);
+
+        GetRecordsResponse response = GetRecordsResponse.builder().records(records).build();
+        when(getRecordsRetrievalStrategy.getRecords(eq(MAX_RECORDS_PER_CALL))).thenReturn(response);
+        when(dataFetcher.isShardEndReached()).thenReturn(false);
+
+        getRecordsCache.start(sequenceNumber, initialPosition);
+
+        try {
+            ProcessRecordsInput result = blockUntilRecordsAvailable(() -> evictPublishedEvent(getRecordsCache, "shardId"), 1000L)
+                    .processRecordsInput();
+        } catch (Exception e) {
+            assertEquals("No records found", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testGetRecordsWithShardEnd() {
+        records = new ArrayList<>();
+
+        final List<KinesisClientRecord> expectedRecords = new ArrayList<>();
+
+        List<ChildShard> childShards = new ArrayList<>();
+        List<String> parentShards = new ArrayList<>();
+        parentShards.add("shardId");
+        ChildShard leftChild = ChildShard.builder()
+                                         .shardId("shardId-000000000001")
+                                         .parentShards(parentShards)
+                                         .hashKeyRange(ShardObjectHelper.newHashKeyRange("0", "49"))
+                                         .build();
+        ChildShard rightChild = ChildShard.builder()
+                                          .shardId("shardId-000000000002")
+                                          .parentShards(parentShards)
+                                          .hashKeyRange(ShardObjectHelper.newHashKeyRange("50", "99"))
+                                          .build();
+        childShards.add(leftChild);
+        childShards.add(rightChild);
+
+        GetRecordsResponse response = GetRecordsResponse.builder().records(records).childShards(childShards).build();
+        when(getRecordsRetrievalStrategy.getRecords(eq(MAX_RECORDS_PER_CALL))).thenReturn(response);
+        when(dataFetcher.isShardEndReached()).thenReturn(true);
+
+        getRecordsCache.start(sequenceNumber, initialPosition);
+        ProcessRecordsInput result = blockUntilRecordsAvailable(() -> evictPublishedEvent(getRecordsCache, "shardId"), 1000L)
+                .processRecordsInput();
+
+        assertEquals(expectedRecords, result.records());
+        assertEquals(childShards, result.childShards());
+        assertTrue(result.isAtShardEnd());
     }
 
     // TODO: Broken test
@@ -269,7 +329,7 @@ public class PrefetchRecordsPublisherTest {
     @Test
     public void testRetryableRetrievalExceptionContinues() {
 
-        GetRecordsResponse response = GetRecordsResponse.builder().millisBehindLatest(100L).records(Collections.emptyList()).build();
+        GetRecordsResponse response = GetRecordsResponse.builder().millisBehindLatest(100L).records(Collections.emptyList()).nextShardIterator(NEXT_SHARD_ITERATOR).build();
         when(getRecordsRetrievalStrategy.getRecords(anyInt())).thenThrow(new RetryableRetrievalException("Timeout", new TimeoutException("Timeout"))).thenReturn(response);
 
         getRecordsCache.start(sequenceNumber, initialPosition);
@@ -292,7 +352,7 @@ public class PrefetchRecordsPublisherTest {
 
         when(getRecordsRetrievalStrategy.getRecords(anyInt())).thenAnswer( i -> GetRecordsResponse.builder().records(
                 Record.builder().data(SdkBytes.fromByteArray(new byte[] { 1, 2, 3 })).sequenceNumber(++sequenceNumberInResponse[0] + "").build())
-                .build());
+                .nextShardIterator(NEXT_SHARD_ITERATOR).build());
 
         getRecordsCache.start(sequenceNumber, initialPosition);
 
@@ -383,7 +443,7 @@ public class PrefetchRecordsPublisherTest {
         // to the subscriber.
         GetRecordsResponse response = GetRecordsResponse.builder().records(
                 Record.builder().data(SdkBytes.fromByteArray(new byte[] { 1, 2, 3 })).sequenceNumber("123").build())
-                .build();
+                .nextShardIterator(NEXT_SHARD_ITERATOR).build();
         when(getRecordsRetrievalStrategy.getRecords(anyInt())).thenReturn(response);
 
         getRecordsCache.start(sequenceNumber, initialPosition);

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/utils/ProcessRecordsInputMatcher.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/utils/ProcessRecordsInputMatcher.java
@@ -45,6 +45,7 @@ public class ProcessRecordsInputMatcher extends TypeSafeDiagnosingMatcher<Proces
         matchers.put("millisBehindLatest",
                 nullOrEquals(template.millisBehindLatest(), ProcessRecordsInput::millisBehindLatest));
         matchers.put("records", nullOrEquals(template.records(), ProcessRecordsInput::records));
+        matchers.put("childShards", nullOrEquals(template.childShards(), ProcessRecordsInput::childShards));
 
         this.template = template;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   </scm>
 
   <properties>
-    <awssdk.version>2.10.0</awssdk.version>
+    <awssdk.version>2.10.25</awssdk.version>
   </properties>
 
   <licenses>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Utilize the ChildShard information from GetRecordsResponse/SubscribeToShard to create new leases when reaching the shard end.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
